### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ bower_components
 .lock-wscript
 
 # Compiled binary addons (https://nodejs.org/api/addons.html)
-build/Release
+build/Release 
 
 # Dependency directories
 node_modules/


### PR DESCRIPTION
¿Qué ha cambiado?
Agregamos al .gitignore soporte para Node.js
- [ ] Frontend
- [ ] Backend
- [x] Configuración del server

# ¿Cómo puedo probar los cambios?
Por ejemplo, los archivos y la carpeta node_modules ya no se suben al repo, ver el archivo .gitignore completo  
¿En que URL y forma puedo ver el update?
